### PR TITLE
Fixed a problem with the -o outputfile option not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ file for more details.
 
 ## Release Notes
 
+### v1.0.1
+
+- fixed a bug where the -o outputfile option did not work properly
+
 ### v1.0.0
 
 - initial release relying on ilib-tmx for tmx related functionality

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tmxtool",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./src/index.js",
     "type": "module",
     "bin": {

--- a/src/diff.js
+++ b/src/diff.js
@@ -32,8 +32,8 @@ export function diff(options, file1, file2) {
     const tmx2 = new TMX({path: file2});
     const difftmx = tmx1.diff(tmx2);
     const diffstring = difftmx.serialize();
-    if (options.args.outputfile) {
-        fs.writeFileSync(options.args.outputfile, diffstring, "utf-8");
+    if (options.opt.outputfile) {
+        fs.writeFileSync(options.opt.outputfile, diffstring, "utf-8");
     } else {
         console.log(diffstring);
     }

--- a/src/merge.js
+++ b/src/merge.js
@@ -37,8 +37,8 @@ export function merge(options, files) {
 
     const mergeTmx = tmxs[0].merge(tmxs.slice(1));
     const mergeString = mergeTmx.serialize();
-    if (options.args.outputfile) {
-        fs.writeFileSync(options.args.outputfile, mergeString, "utf-8");
+    if (options.opt.outputfile) {
+        fs.writeFileSync(options.opt.outputfile, mergeString, "utf-8");
     } else {
         console.log(mergeString);
     }

--- a/test/testdiff.js
+++ b/test/testdiff.js
@@ -27,7 +27,7 @@ export const testdiff = {
         test.expect(13);
 
         diff({
-            args: {
+            opt: {
                 outputfile: "./test/testfiles/diff.tmx"
             }
         }, "./test/testfiles/test1.tmx", "./test/testfiles/test2.tmx");
@@ -65,7 +65,7 @@ export const testdiff = {
         test.expect(4);
 
         diff({
-            args: {
+            opt: {
                 outputfile: "./test/testfiles/diff.tmx"
             }
         }, "./test/testfiles/test1.tmx", "./test/testfiles/test1.tmx");
@@ -88,7 +88,7 @@ export const testdiff = {
         test.expect(13);
 
         diff({
-            args: {
+            opt: {
                 outputfile: "./test/testfiles/diff.tmx"
             }
         }, "./test/testfiles/testvariants1.tmx", "./test/testfiles/testvariants2.tmx");

--- a/test/testmerge.js
+++ b/test/testmerge.js
@@ -27,7 +27,7 @@ export const testmerge = {
         test.expect(22);
 
         merge({
-            args: {
+            opt: {
                 outputfile: "./test/testfiles/merge.tmx"
             }
         }, ["./test/testfiles/test1.tmx", "./test/testfiles/test2.tmx"]);
@@ -78,7 +78,7 @@ export const testmerge = {
         test.expect(13);
 
         merge({
-            args: {
+            opt: {
                 outputfile: "./test/testfiles/merge.tmx"
             }
         }, ["./test/testfiles/test1.tmx", "./test/testfiles/test1.tmx"]);
@@ -115,7 +115,7 @@ export const testmerge = {
         test.expect(24);
 
         merge({
-            args: {
+            opt: {
                 outputfile: "./test/testfiles/merge.tmx"
             }
         }, ["./test/testfiles/testvariants1.tmx", "./test/testfiles/testvariants2.tmx"]);


### PR DESCRIPTION
- The options-parser package puts options in the options.opt object, and the arguments in the options.args object and I had the wrong one for the -o option